### PR TITLE
2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-coffee",
   "description": "Compile CoffeeScript files",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "homepage": "http://github.com/wearefractal/gulp-coffee",
   "repository": "git://github.com/wearefractal/gulp-coffee.git",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",


### PR DESCRIPTION
You wanted a PR for bumping version. Here it is (see https://github.com/contra/gulp-coffee/issues/74).

Please merge and do a `npm publish` so we can use updated `coffee-script` dependency.