### PR TITLE
Change Coffeescript dependency name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gulp.task('coffee', function() {
 
 ## Options
 
-- `coffee` (optional): A reference to a custom CoffeeScript version/fork (eg. `coffee: require('my-name/coffee-script')`)
+- `coffee` (optional): A reference to a custom CoffeeScript version/fork (eg. `coffee: require('my-name/coffeescript')`)
 
 Additionally, the options object supports all options that are supported by the standard CoffeeScript compiler.
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (opt) {
 
     var options = merge({
       bare: false,
-      coffee: require('coffee-script'),
+      coffee: require('coffeescript'),
       header: false,
       sourceMap: !!file.sourceMap,
       sourceRoot: false,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gulpplugin"
   ],
   "dependencies": {
-    "coffee-script": "^1.10.0",
+    "coffeescript": "^1.10.0",
     "gulp-util": "^3.0.2",
     "merge": "^1.2.0",
     "through2": "^2.0.1",

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,6 @@
 var coffee = require('../');
 var should = require('should');
-var coffeescript = require('coffee-script');
+var coffeescript = require('coffeescript');
 var gutil = require('gulp-util');
 var fs = require('fs');
 var path = require('path');


### PR DESCRIPTION
Coffeescript NPM package has moved.

https://www.npmjs.com/package/coffee-script

Dependency needs to change from 'coffee-script' to 'coffeescript'.