### PR TITLE
Bump Coffeescript to version 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,9 +123,9 @@
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
     },
     "coffeescript": {
-      "version": "1.12.8",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.8.tgz",
-      "integrity": "sha512-2X/1abVnSwc3+D/pPqxrjYHCHnhZz1U2p2qJJMhS40nPn5OmKMidJExYrOmzWeXCmOl3Hkm06cT7iQ4yKB+I2Q=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.1.0.tgz",
+      "integrity": "sha512-RuEF4gFUV9QSFPREl8gx6w0vS6Ncnr0Nd71lOmxSHfKQFQI66meE54Y636TACbe55j2Lwi6R1O8lOa0dD550GA=="
     },
     "commander": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gulpplugin"
   ],
   "dependencies": {
-    "coffeescript": "^1.10.0",
+    "coffeescript": "^2.1.0",
     "gulp-util": "^3.0.2",
     "merge": "^1.2.0",
     "through2": "^2.0.1",


### PR DESCRIPTION
 I noticed you had mentioned in #78 that you were meaning to bump the Coffeescript compiler to version 2.x. I bumped the version in `package.json` and `package-lock.json`.

Test-running the updated code on compiling Coffeescript with Gulp worked just fine, no breakages. Previously I had been using the solution mentioned by @objectkit in the #78 thread, but I think it would be better to switch the default compiler to Coffeescript 2.